### PR TITLE
444: Move storefront service connector to MessageBroker.

### DIFF
--- a/app/code/Magento/CatalogMessageBroker/Model/MessageBus/Category/DeleteCategoriesConsumer.php
+++ b/app/code/Magento/CatalogMessageBroker/Model/MessageBus/Category/DeleteCategoriesConsumer.php
@@ -6,9 +6,9 @@
 
 namespace Magento\CatalogMessageBroker\Model\MessageBus\Category;
 
-use Magento\CatalogStorefrontApi\Api\CatalogServerInterface;
 use Magento\CatalogStorefrontApi\Api\Data\DeleteCategoriesRequestInterfaceFactory;
 use Magento\CatalogMessageBroker\Model\MessageBus\ConsumerEventInterface;
+use Magento\MessageBroker\Model\ServiceConnector\Connector;
 use Psr\Log\LoggerInterface;
 
 /**
@@ -22,9 +22,9 @@ class DeleteCategoriesConsumer implements ConsumerEventInterface
     private $deleteCategoriesRequestInterfaceFactory;
 
     /**
-     * @var CatalogServerInterface
+     * @var Connector
      */
-    private $catalogServer;
+    private $connector;
 
     /**
      * @var LoggerInterface
@@ -33,16 +33,16 @@ class DeleteCategoriesConsumer implements ConsumerEventInterface
 
     /**
      * @param DeleteCategoriesRequestInterfaceFactory $deleteCategoriesRequestInterfaceFactory
-     * @param CatalogServerInterface $catalogServer
+     * @param Connector $connector
      * @param LoggerInterface $logger
      */
     public function __construct(
         DeleteCategoriesRequestInterfaceFactory $deleteCategoriesRequestInterfaceFactory,
-        CatalogServerInterface $catalogServer,
+        Connector $connector,
         LoggerInterface $logger
     ) {
         $this->deleteCategoriesRequestInterfaceFactory = $deleteCategoriesRequestInterfaceFactory;
-        $this->catalogServer = $catalogServer;
+        $this->connector = $connector;
         $this->logger = $logger;
     }
 
@@ -60,7 +60,10 @@ class DeleteCategoriesConsumer implements ConsumerEventInterface
         $deleteCategoryRequest = $this->deleteCategoriesRequestInterfaceFactory->create();
         $deleteCategoryRequest->setCategoryIds($ids);
         $deleteCategoryRequest->setStore($scope);
-        $importResult = $this->catalogServer->deleteCategories($deleteCategoryRequest);
+
+        $importResult = $this->connector
+            ->getConnection(\Magento\CatalogMessageBroker\Model\ServiceConfig::SERVICE_NAME_CATALOG)
+            ->deleteCategories($deleteCategoryRequest);
 
         if ($importResult->getStatus() === false) {
             $this->logger->error(sprintf('Categories deletion has failed: "%s"', $importResult->getMessage()));

--- a/app/code/Magento/CatalogMessageBroker/Model/MessageBus/Category/PublishCategoriesConsumer.php
+++ b/app/code/Magento/CatalogMessageBroker/Model/MessageBus/Category/PublishCategoriesConsumer.php
@@ -9,7 +9,7 @@ namespace Magento\CatalogMessageBroker\Model\MessageBus\Category;
 use Magento\CatalogExport\Event\Data\Entity;
 use Magento\CatalogMessageBroker\Model\Converter\AttributeCodesConverter;
 use Magento\CatalogMessageBroker\Model\FetchCategoriesInterface;
-use Magento\CatalogMessageBroker\Model\StorefrontConnector\Connector;
+use Magento\MessageBroker\Model\ServiceConnector\Connector;
 use Magento\CatalogStorefrontApi\Api\Data\ImportCategoriesRequestInterfaceFactory;
 use Magento\CatalogMessageBroker\Model\MessageBus\ConsumerEventInterface;
 use Magento\CatalogStorefrontApi\Api\Data\ImportCategoryDataRequestInterface;
@@ -193,7 +193,7 @@ class PublishCategoriesConsumer implements ConsumerEventInterface
         $importCategoriesRequest->setStore($storeCode);
 
         $importResult = $this->connector
-            ->getConnection(\Magento\CatalogMessageBroker\Model\ServiceConfig::SERVICE_NAME)
+            ->getConnection(\Magento\CatalogMessageBroker\Model\ServiceConfig::SERVICE_NAME_CATALOG)
             ->importCategories($importCategoriesRequest);
 
         if ($importResult->getStatus() === false) {

--- a/app/code/Magento/CatalogMessageBroker/Model/MessageBus/Product/DeleteProductsConsumer.php
+++ b/app/code/Magento/CatalogMessageBroker/Model/MessageBus/Product/DeleteProductsConsumer.php
@@ -6,9 +6,9 @@
 
 namespace Magento\CatalogMessageBroker\Model\MessageBus\Product;
 
-use Magento\CatalogStorefrontApi\Api\CatalogServerInterface;
 use Magento\CatalogStorefrontApi\Api\Data\DeleteProductsRequestInterfaceFactory;
 use Magento\CatalogMessageBroker\Model\MessageBus\ConsumerEventInterface;
+use Magento\MessageBroker\Model\ServiceConnector\Connector;
 use Psr\Log\LoggerInterface;
 
 /**
@@ -22,9 +22,9 @@ class DeleteProductsConsumer implements ConsumerEventInterface
     private $deleteProductsRequestInterfaceFactory;
 
     /**
-     * @var CatalogServerInterface
+     * @var Connector
      */
-    private $catalogServer;
+    private $connector;
 
     /**
      * @var LoggerInterface
@@ -33,16 +33,16 @@ class DeleteProductsConsumer implements ConsumerEventInterface
 
     /**
      * @param DeleteProductsRequestInterfaceFactory $deleteProductsRequestInterfaceFactory
-     * @param CatalogServerInterface $catalogServer
+     * @param Connector $connector
      * @param LoggerInterface $logger
      */
     public function __construct(
         DeleteProductsRequestInterfaceFactory $deleteProductsRequestInterfaceFactory,
-        CatalogServerInterface $catalogServer,
+        Connector $connector,
         LoggerInterface $logger
     ) {
         $this->deleteProductsRequestInterfaceFactory = $deleteProductsRequestInterfaceFactory;
-        $this->catalogServer = $catalogServer;
+        $this->connector = $connector;
         $this->logger = $logger;
     }
 
@@ -62,7 +62,10 @@ class DeleteProductsConsumer implements ConsumerEventInterface
         $deleteProductRequest->setStore($scope);
 
         try {
-            $importResult = $this->catalogServer->deleteProducts($deleteProductRequest);
+            $importResult = $this->connector
+                ->getConnection(\Magento\CatalogMessageBroker\Model\ServiceConfig::SERVICE_NAME_CATALOG)
+                ->deleteProducts($deleteProductRequest);
+
             if ($importResult->getStatus() === false) {
                 $this->logger->error(sprintf('Products deletion has failed: "%s"', $importResult->getMessage()));
             }

--- a/app/code/Magento/CatalogMessageBroker/Model/MessageBus/ProductVariants/DeleteProductVariantsConsumer.php
+++ b/app/code/Magento/CatalogMessageBroker/Model/MessageBus/ProductVariants/DeleteProductVariantsConsumer.php
@@ -5,9 +5,9 @@
  */
 namespace Magento\CatalogMessageBroker\Model\MessageBus\ProductVariants;
 
-use Magento\CatalogStorefrontApi\Api\VariantServiceServerInterface;
 use Magento\CatalogStorefrontApi\Api\Data\DeleteVariantsRequestInterfaceFactory;
 use Magento\CatalogMessageBroker\Model\MessageBus\ConsumerEventInterface;
+use Magento\MessageBroker\Model\ServiceConnector\Connector;
 use Psr\Log\LoggerInterface;
 
 /**
@@ -21,9 +21,9 @@ class DeleteProductVariantsConsumer implements ConsumerEventInterface
     private $deleteVariantsRequestInterfaceFactory;
 
     /**
-     * @var VariantServiceServerInterface
+     * @var Connector
      */
-    private $variantsServer;
+    private $connector;
 
     /**
      * @var LoggerInterface
@@ -32,16 +32,16 @@ class DeleteProductVariantsConsumer implements ConsumerEventInterface
 
     /**
      * @param DeleteVariantsRequestInterfaceFactory $deleteVariantsRequestInterfaceFactory
-     * @param VariantServiceServerInterface $variantsServer
+     * @param Connector $connector,
      * @param LoggerInterface $logger
      */
     public function __construct(
         DeleteVariantsRequestInterfaceFactory $deleteVariantsRequestInterfaceFactory,
-        VariantServiceServerInterface $variantsServer,
+        Connector $connector,
         LoggerInterface $logger
     ) {
         $this->deleteVariantsRequestInterfaceFactory = $deleteVariantsRequestInterfaceFactory;
-        $this->variantsServer = $variantsServer;
+        $this->connector = $connector;
         $this->logger = $logger;
     }
 
@@ -59,7 +59,10 @@ class DeleteProductVariantsConsumer implements ConsumerEventInterface
         $deleteVariantsRequest->setId($ids);
 
         try {
-            $importResult = $this->variantsServer->deleteProductVariants($deleteVariantsRequest);
+            $importResult = $this->connector
+                ->getConnection(\Magento\CatalogMessageBroker\Model\ServiceConfig::SERVICE_NAME_VARIANTS)
+                ->deleteProductVariants($deleteVariantsRequest);
+
             if ($importResult->getStatus() === false) {
                 $this->logger->error(
                     sprintf('Product variants deletion has failed: "%s"', $importResult->getMessage())

--- a/app/code/Magento/CatalogMessageBroker/Model/MessageBus/ProductVariants/PublishProductVariantsConsumer.php
+++ b/app/code/Magento/CatalogMessageBroker/Model/MessageBus/ProductVariants/PublishProductVariantsConsumer.php
@@ -11,7 +11,7 @@ use Magento\CatalogMessageBroker\Model\MessageBus\ConsumerEventInterface;
 use Magento\CatalogStorefrontApi\Api\Data\ImportVariantsRequestInterfaceFactory;
 use Magento\CatalogStorefrontApi\Api\Data\ProductVariantImportInterface;
 use Magento\CatalogStorefrontApi\Api\Data\ProductVariantImportMapper;
-use Magento\CatalogStorefrontApi\Api\VariantServiceServerInterface;
+use Magento\MessageBroker\Model\ServiceConnector\Connector;
 use Psr\Log\LoggerInterface;
 
 /**
@@ -30,9 +30,9 @@ class PublishProductVariantsConsumer implements ConsumerEventInterface
     private $fetchProductVariants;
 
     /**
-     * @var VariantServiceServerInterface
+     * @var Connector
      */
-    private $variantService;
+    private $connector;
 
     /**
      * @var ImportVariantsRequestInterfaceFactory
@@ -47,20 +47,20 @@ class PublishProductVariantsConsumer implements ConsumerEventInterface
     /**
      * @param LoggerInterface $logger
      * @param FetchProductVariantsInterface $fetchProductVariants
-     * @param VariantServiceServerInterface $variantService
+     * @param Connector $connector,
      * @param ImportVariantsRequestInterfaceFactory $importVariantsRequestInterfaceFactory
      * @param ProductVariantImportMapper $productVariantImportMapper
      */
     public function __construct(
         LoggerInterface $logger,
         FetchProductVariantsInterface $fetchProductVariants,
-        VariantServiceServerInterface $variantService,
+        Connector $connector,
         ImportVariantsRequestInterfaceFactory $importVariantsRequestInterfaceFactory,
         ProductVariantImportMapper $productVariantImportMapper
     ) {
         $this->logger = $logger;
         $this->fetchProductVariants = $fetchProductVariants;
-        $this->variantService = $variantService;
+        $this->connector = $connector;
         $this->importVariantsRequestInterfaceFactory = $importVariantsRequestInterfaceFactory;
         $this->productVariantImportMapper = $productVariantImportMapper;
     }
@@ -108,7 +108,10 @@ class PublishProductVariantsConsumer implements ConsumerEventInterface
         $importVariantsRequest->setVariants($variants);
 
         try {
-            $importResult = $this->variantService->importProductVariants($importVariantsRequest);
+            $importResult = $this->connector
+                ->getConnection(\Magento\CatalogMessageBroker\Model\ServiceConfig::SERVICE_NAME_VARIANTS)
+                ->importProductVariants($importVariantsRequest);
+
             if ($importResult->getStatus() === false) {
                 $this->logger->error(sprintf('Product variants import failed: "%s"', $importResult->getMessage()));
             }

--- a/app/code/Magento/CatalogMessageBroker/Model/Publisher/ProductPublisher.php
+++ b/app/code/Magento/CatalogMessageBroker/Model/Publisher/ProductPublisher.php
@@ -6,11 +6,9 @@
 
 namespace Magento\CatalogMessageBroker\Model\Publisher;
 
-use Magento\CatalogExport\Model\ChangedEntitiesMessageBuilder;
-use Magento\CatalogMessageBroker\Model\FetchProductsInterface;
 use Magento\CatalogMessageBroker\Model\MessageBus\Product\PublishProductsConsumer;
 use Magento\CatalogMessageBroker\Model\DataMapper;
-use Magento\CatalogMessageBroker\Model\StorefrontConnector\Connector;
+use Magento\MessageBroker\Model\ServiceConnector\Connector;
 use Magento\CatalogStorefrontApi\Api\Data\ImportProductDataRequestMapper;
 use Magento\CatalogStorefrontApi\Api\Data\ImportProductsRequestInterface;
 use Magento\CatalogStorefrontApi\Api\Data\ImportProductsRequestInterfaceFactory;
@@ -153,7 +151,7 @@ class ProductPublisher
         $importProductRequest->setStore($storeCode);
 
         $importResult = $this->connector
-            ->getConnection(\Magento\CatalogMessageBroker\Model\ServiceConfig::SERVICE_NAME)
+            ->getConnection(\Magento\CatalogMessageBroker\Model\ServiceConfig::SERVICE_NAME_CATALOG)
             ->importProducts($importProductRequest);
 
         if ($importResult->getStatus() === false) {

--- a/app/code/Magento/CatalogMessageBroker/Model/ServiceConfig.php
+++ b/app/code/Magento/CatalogMessageBroker/Model/ServiceConfig.php
@@ -13,7 +13,12 @@ namespace Magento\CatalogMessageBroker\Model;
 class ServiceConfig
 {
     /**
-     * Service name
+     * Catalog service name
      */
-    public const SERVICE_NAME = 'catalog';
+    public const SERVICE_NAME_CATALOG = 'catalog';
+
+    /**
+     * Catalog service name
+     */
+    public const SERVICE_NAME_VARIANTS = 'variants';
 }

--- a/app/code/Magento/CatalogMessageBroker/Model/ServiceConnector/Configuration/GrpcConfigurationProvider.php
+++ b/app/code/Magento/CatalogMessageBroker/Model/ServiceConnector/Configuration/GrpcConfigurationProvider.php
@@ -6,12 +6,13 @@
 
 declare(strict_types=1);
 
-namespace Magento\CatalogMessageBroker\Model\StorefrontConnector\Configuration;
+namespace Magento\CatalogMessageBroker\Model\ServiceConnector\Configuration;
 
 use Grpc\ChannelCredentials;
 use Magento\Framework\App\DeploymentConfig;
 use Magento\Framework\Exception\FileSystemException;
 use Magento\Framework\Exception\RuntimeException;
+use Magento\MessageBroker\Model\ServiceConnector\Configuration\ConfigurationProviderInterface;
 
 /**
  * Configuration provider class for gRPC connection.

--- a/app/code/Magento/CatalogMessageBroker/etc/di.xml
+++ b/app/code/Magento/CatalogMessageBroker/etc/di.xml
@@ -50,28 +50,46 @@
         </arguments>
     </type>
 
-    <type name="Magento\CatalogMessageBroker\Model\StorefrontConnector\Connector">
+    <type name="Magento\MessageBroker\Model\ServiceConnector\Connector">
         <arguments>
-            <argument name="connectionType" xsi:type="init_parameter">
-                Magento\MessageBroker\Model\Installer::SERVICE_COMMUNICATION_CONNECTION_TYPE
+            <argument name="connectionTypeMap" xsi:type="array">
+                <item xsi:type="const" name="catalog">
+                    Magento\MessageBroker\Model\Installer::DEFAULT_CONNECTION_TYPE
+                </item>
+                <item xsi:type="const" name="variants">
+                    Magento\MessageBroker\Model\Installer::DEFAULT_CONNECTION_TYPE
+                </item>
             </argument>
         </arguments>
     </type>
 
-    <type name="Magento\CatalogMessageBroker\Model\StorefrontConnector\ConnectionPool">
+    <type name="Magento\MessageBroker\Model\ServiceConnector\ConnectionPool">
         <arguments>
             <argument name="connectionMap" xsi:type="array">
-                <item name="network" xsi:type="string">Magento\CatalogStorefrontApi\Api\Catalog</item>
-                <item name="in-memory" xsi:type="string">Magento\CatalogStorefrontApi\Api\InMemoryCatalog</item>
+                <item xsi:type="array" name="catalog">
+                    <item name="network" xsi:type="string">Magento\CatalogStorefrontApi\Api\Catalog</item>
+                    <item name="in-memory" xsi:type="string">Magento\CatalogStorefrontApi\Api\InMemoryCatalog</item>
+                </item>
+                <item xsi:type="array" name="variants">
+                    <item name="network" xsi:type="string">Magento\CatalogStorefrontApi\Api\VariantService</item>
+                    <item name="in-memory" xsi:type="string">Magento\CatalogStorefrontApi\Api\InMemoryVariantService</item>
+                </item>
             </argument>
         </arguments>
     </type>
 
-    <type name="Magento\CatalogMessageBroker\Model\StorefrontConnector\Configuration\ConfigurationProviderPool">
+    <type name="Magento\MessageBroker\Model\ServiceConnector\Configuration\ConfigurationProviderPool">
         <arguments>
             <argument name="providersMap" xsi:type="array">
-                <item name="network" xsi:type="object">
-                    Magento\CatalogMessageBroker\Model\StorefrontConnector\Configuration\GrpcConfigurationProvider
+                <item xsi:type="array" name="catalog">
+                    <item name="network" xsi:type="object">
+                        Magento\CatalogMessageBroker\Model\ServiceConnector\Configuration\GrpcConfigurationProvider
+                    </item>
+                </item>
+                <item xsi:type="array" name="variants">
+                    <item name="network" xsi:type="object">
+                        Magento\CatalogMessageBroker\Model\ServiceConnector\Configuration\GrpcConfigurationProvider
+                    </item>
                 </item>
             </argument>
         </arguments>
@@ -80,7 +98,8 @@
     <type name="\Magento\MessageBroker\Console\Command\AddGrpcConnection">
         <arguments>
             <argument name="supportedServices" xsi:type="array">
-                <item xsi:type="const" name="catalog">Magento\CatalogMessageBroker\Model\ServiceConfig::SERVICE_NAME</item>
+                <item xsi:type="const" name="catalog">Magento\CatalogMessageBroker\Model\ServiceConfig::SERVICE_NAME_CATALOG</item>
+                <item xsi:type="const" name="variants">Magento\CatalogMessageBroker\Model\ServiceConfig::SERVICE_NAME_VARIANTS</item>
             </argument>
         </arguments>
     </type>

--- a/app/code/Magento/MessageBroker/Model/Installer.php
+++ b/app/code/Magento/MessageBroker/Model/Installer.php
@@ -15,6 +15,7 @@ class Installer
      */
     public const SERVICE_COMMUNICATION_CONNECTION_TYPE = 'GRPC_CONNECTION_TYPE';
     public const DEFAULT_CONNECTION_TYPE = 'in-memory';
+    public const NETWORK_CONNECTION_TYPE = 'network';
 
     /**
      * Configuration for AMQP

--- a/app/code/Magento/MessageBroker/Model/ServiceConnector/Configuration/ConfigurationProviderInterface.php
+++ b/app/code/Magento/MessageBroker/Model/ServiceConnector/Configuration/ConfigurationProviderInterface.php
@@ -6,10 +6,10 @@
 
 declare(strict_types=1);
 
-namespace Magento\CatalogMessageBroker\Model\StorefrontConnector\Configuration;
+namespace Magento\MessageBroker\Model\ServiceConnector\Configuration;
 
 /**
- * Interface for configuration providers for storefront connection.
+ * Interface for configuration providers for service connection.
  */
 interface ConfigurationProviderInterface
 {

--- a/app/code/Magento/MessageBroker/Model/ServiceConnector/Configuration/ConfigurationProviderPool.php
+++ b/app/code/Magento/MessageBroker/Model/ServiceConnector/Configuration/ConfigurationProviderPool.php
@@ -6,7 +6,7 @@
 
 declare(strict_types=1);
 
-namespace Magento\CatalogMessageBroker\Model\StorefrontConnector\Configuration;
+namespace Magento\MessageBroker\Model\ServiceConnector\Configuration;
 
 /**
  * Pool of configuration providers for storefront connection.
@@ -35,10 +35,10 @@ class ConfigurationProviderPool
      */
     public function retrieveByConnectionType(string $type, string $connectionName): array
     {
-        if (!isset($this->providersMap[$type])) {
+        if (!isset($this->providersMap[$connectionName][$type])) {
             return [];
         }
 
-        return $this->providersMap[$type]->provide($connectionName);
+        return $this->providersMap[$connectionName][$type]->provide($connectionName);
     }
 }

--- a/app/code/Magento/MessageBroker/Model/ServiceConnector/ConnectionPool.php
+++ b/app/code/Magento/MessageBroker/Model/ServiceConnector/ConnectionPool.php
@@ -6,9 +6,8 @@
 
 declare(strict_types=1);
 
-namespace Magento\CatalogMessageBroker\Model\StorefrontConnector;
+namespace Magento\MessageBroker\Model\ServiceConnector;
 
-use Magento\CatalogStorefrontApi\Api\CatalogInterface;
 use Magento\Framework\ObjectManagerInterface;
 
 /**
@@ -27,7 +26,7 @@ class ConnectionPool
     private $connectionMap;
 
     /**
-     * @var CatalogInterface[]
+     * @var array
      */
     private $registry;
 
@@ -44,25 +43,28 @@ class ConnectionPool
     }
 
     /**
-     * Retrieve connection by specified type.
+     * Retrieve connection for specified service by type.
      *
+     * @param string $serviceName
      * @param string $type
      * @param array $params
      *
-     * @return CatalogInterface
+     * @return mixed
      *
-     * @throws \InvalidArgumentException
      */
-    public function retrieveByConnectionType(string $type, array $params): CatalogInterface
+    public function retrieveByConnectionType(string $serviceName, string $type, array $params)
     {
-        if (!isset($this->connectionMap[$type])) {
-            throw new \InvalidArgumentException('Invalid connection type provided.');
+        if (!isset($this->connectionMap[$serviceName][$type])) {
+            throw new \InvalidArgumentException('Invalid connection type or service name provided.');
         }
 
-        if (!isset($this->registry[$type])) {
-            $this->registry[$type] = $this->objectManager->create($this->connectionMap[$type], $params);
+        if (!isset($this->registry[$serviceName][$type])) {
+            $this->registry[$serviceName][$type] = $this->objectManager->create(
+                $this->connectionMap[$serviceName][$type],
+                $params
+            );
         }
 
-        return $this->registry[$type];
+        return $this->registry[$serviceName][$type];
     }
 }

--- a/app/code/Magento/MessageBroker/Model/ServiceConnector/Connector.php
+++ b/app/code/Magento/MessageBroker/Model/ServiceConnector/Connector.php
@@ -6,10 +6,10 @@
 
 declare(strict_types=1);
 
-namespace Magento\CatalogMessageBroker\Model\StorefrontConnector;
+namespace Magento\MessageBroker\Model\ServiceConnector;
 
-use Magento\CatalogMessageBroker\Model\StorefrontConnector\Configuration\ConfigurationProviderPool;
-use Magento\CatalogStorefrontApi\Api\CatalogInterface;
+use Magento\MessageBroker\Model\Installer;
+use Magento\MessageBroker\Model\ServiceConnector\Configuration\ConfigurationProviderPool;
 
 /**
  * Class responsible for providing connection by specified connection type
@@ -27,36 +27,39 @@ class Connector
     private $configurationProviderPool;
 
     /**
-     * @var string
+     * @var array
      */
-    private $connectionType;
+    private $connectionTypeMap;
 
     /**
      * @param ConnectionPool $connectionPool
      * @param ConfigurationProviderPool $configurationProviderPool
-     * @param string $connectionType
+     * @param array $connectionTypeMap
      */
     public function __construct(
         ConnectionPool $connectionPool,
         ConfigurationProviderPool $configurationProviderPool,
-        string $connectionType = \Magento\MessageBroker\Model\Installer::DEFAULT_CONNECTION_TYPE
+        array $connectionTypeMap = []
     ) {
         $this->connectionPool = $connectionPool;
         $this->configurationProviderPool = $configurationProviderPool;
-        $this->connectionType = $connectionType;
+        $this->connectionTypeMap = $connectionTypeMap;
     }
 
     /**
-     * Retrieve storefront connection.
+     * Retrieve service connection.
      *
      * @param string $connectionName
-     * @return CatalogInterface
+     * @return mixed
      */
-    public function getConnection(string $connectionName): CatalogInterface
+    public function getConnection(string $connectionName)
     {
+        $connectionType = $this->connectionTypeMap[$connectionName] ?? Installer::DEFAULT_CONNECTION_TYPE;
+
         return $this->connectionPool->retrieveByConnectionType(
-            $this->connectionType,
-            $this->configurationProviderPool->retrieveByConnectionType($this->connectionType, $connectionName)
+            $connectionName,
+            $connectionType,
+            $this->configurationProviderPool->retrieveByConnectionType($connectionType, $connectionName)
         );
     }
 }

--- a/app/code/Magento/MessageBroker/Stub/Encoder.php
+++ b/app/code/Magento/MessageBroker/Stub/Encoder.php
@@ -18,7 +18,7 @@ class Encoder implements EncoderInterface
     /**
      * @var Json
      */
-    private Json $json;
+    private $json;
 
     /**
      * Encoder constructor.


### PR DESCRIPTION
Move storefront service connector to MessageBroker.

### Description (*)
Move storefront service connector to MessageBroker. 
Improve connector to add possibility to get connection by type and name. 
Configure connector for catalog and variants service.

### Fixed Issues (if relevant)

1. Fixes https://github.com/magento/catalog-storefront/issues/444


### Code Review Checklist (*)

See detailed [checklist](https://github.com/magento/storefront-message-broker/blob/develop/dev/docs/projectAgreements/Code-Review-checklist.md)

- [ ] Story AC is completed
- [ ] proposed changes correspond to [Magento Technical Vision](https://devdocs.magento.com/guides/v2.2/coding-standards/technical-guidelines.html)
- [ ] new or changed code is covered with web-api/integration tests (if applicable)
  - expected results in test verified with data from fixture
- [ ] no backward incompatible changes
- [ ] Class usage: magento/storefront-message-broker repo don't use directly classes from magento/saas-export repo and vise-verse
  - Check composer.json dependencies
- [ ] Legacy code is deleted


